### PR TITLE
fix(plugin): do not overwrite existing cookie in res object

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -109,7 +109,13 @@ function setCookie(ctx, name, value, maxAge = MAX_AGE) {
     document.cookie = serializedCookie
   } else if (process.server && ctx.res) {
     // Send Set-Cookie header from server side
-    ctx.res.setHeader('Set-Cookie', serializedCookie)
+    const prev = ctx.res.getHeader('Set-Cookie')
+    let value = serializedCookie
+    if (prev) {
+      value = Array.isArray(prev) ? prev.concat(serializedCookie)
+        : [prev, serializedCookie]
+    }
+    ctx.res.setHeader('Set-Cookie', value)
   }
 }
 


### PR DESCRIPTION
Currently the cookie setting code overwrite any existing `set-cookie` header in pending response
this PR fixes this by appending it instead