### PR TITLE
fix(plugin): fix fetch experiment ID from cookie

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -25,9 +25,10 @@ function assignExperiment(ctx) {
   // Try to restore from cookie
   const cookie = getCookie(ctx, 'exp') || '' // experimentID.var1-var2
   const [cookieExp, cookieVars] = cookie.split('.')
-  if (cookieExp.length) {
+  if (cookieExp && cookieVars) {
     // Try to find experiment with that id
-    experimentIndex = experiments.findIndex(exp => exp.experimentID === cookie[0])
+    experimentIndex = experiments.findIndex(exp => exp.experimentID === cookieExp)
+    experiment = experiments[experimentIndex]
 
     // Variant indexes
     variantIndexes = cookieVars.split('-').map(v => parseInt(v))


### PR DESCRIPTION
Current the code bugs out when invalid entries without `.` is in the cookie, so I added checking for `cookieVars`
`cookieExp` should be used instead of `cookie[0]`, which the latter is just 1 char instead of the whole experiment ID string.